### PR TITLE
New option : a folder to store the generated files

### DIFF
--- a/lib/markdown-themeable-pdf.js
+++ b/lib/markdown-themeable-pdf.js
@@ -156,6 +156,12 @@ module.exports = markdownThemeablePdf = {
             default: true,
             description: 'Open PDF inside Atom with <a href="https://atom.io/packages/pdf-view">pdf-view</a> package.',
             order: 200
+        },
+		customGenerationFolder: {
+            type: 'string',
+            default: '',
+            description: 'Folder at the root of your project, in which the generated files will be stored. Keep empty to generate in the same directory as the source file.',
+            order: 210
         }
     },
     subscriptions: null,
@@ -231,7 +237,7 @@ module.exports = markdownThemeablePdf = {
 
         var exportType = atom.config.get('markdown-themeable-pdf.exportFileType');
         var destFileBase = fileInfo.name + '.' + exportType;
-        var destFile = path.resolve(fileInfo.dir, destFileBase);
+        var destFile = this.getGeneratedFullPath(fileInfo.dir, destFileBase);
         var hljs = require('highlight.js');
         var cheerio = require('cheerio');
 
@@ -527,7 +533,7 @@ module.exports = markdownThemeablePdf = {
         return ('file:///' + path.resolve(to, src)).replace(/\\/g, '/');
     },
     /**
-     * Get config file path
+     * Get config file path 
      *
      * @param  {string} relativePath Relative path to config file
      * @param  {string} filePath     Path to current file
@@ -565,5 +571,27 @@ module.exports = markdownThemeablePdf = {
         }
 
         return currentBasePath;
-    }
+    },
+	/**
+     * Get absolute path of a generated file
+     *
+     * @param  {string} sourceDirectory   Absolute path of source file
+	 * @param  {string} generatedFilename Name of the file being generated
+     * @return {string}                   Absolute path of generated file
+     */
+	getGeneratedFullPath: function (sourceDirectory, generatedFilename) {
+		var generatedPath = '';
+		var generationFolder = atom.config.get('markdown-themeable-pdf.customGenerationFolder');
+		if (generationFolder.length > 0) {
+			var rootDirectory = markdownThemeablePdf.getCurrentBasePath(sourceDirectory);
+			var fullGenerationFolder = path.join(rootDirectory, generationFolder);
+			
+			fs.mkdir(fullGenerationFolder);
+			generatedPath = path.resolve(fullGenerationFolder, generatedFilename);
+		} else {
+			generatedPath = path.resolve(sourceDirectory, generatedFilename);
+		}
+		
+		return generatedPath;
+	}
 };


### PR DESCRIPTION
Sometimes, the pdf generated should be located in a specific folder, not in the same as the source files.
Here's what I set for my own use.
A configuration variable can be set to a folder at the root of the project.
If empty, the package will work like before.
If set, this folder is created (if not existing), and the generated files are saved there instead of the source directory.
